### PR TITLE
fix zip extraction

### DIFF
--- a/codes/downloader/downloader.py
+++ b/codes/downloader/downloader.py
@@ -63,7 +63,7 @@ def main():
                 if name.endswith('.zip'):
                     new_dir = name[:-4]
                     os.makedirs(new_dir, exist_ok=True)
-                    shutil.unpack_archive(name, new_path, 'zip')
+                    shutil.unpack_archive(name, new_dir, 'zip')
                     os.remove(name)
     else:
         print("Cannot get the dataset")


### PR DESCRIPTION
Fixes small variable typo causing:

Traceback (most recent call last):
  File "codes/downloader/downloader.py", line 74, in <module>
    main()
  File "codes/downloader/downloader.py", line 66, in main
    shutil.unpack_archive(name, new_path, 'zip')
NameError: name 'new_path' is not defined